### PR TITLE
fix(utils/uid/uuid.go): ignore uuid.NewV4() returned error

### DIFF
--- a/utils/uid/uuid.go
+++ b/utils/uid/uuid.go
@@ -6,7 +6,7 @@ import (
 )
 
 func NewId() string {
-	id := uuid.NewV4()
+	id, _ := uuid.NewV4()
 	b64 := base64.URLEncoding.EncodeToString(id.Bytes()[:12])
 	return b64
 }


### PR DESCRIPTION
因为 https://github.com/satori/go.uuid 的 uuid.NewV4() 变更