### PR TITLE
huge performance improvement

### DIFF
--- a/protocol/httpflv/server.go
+++ b/protocol/httpflv/server.go
@@ -51,26 +51,31 @@ func (server *Server) getStreams(w http.ResponseWriter, r *http.Request) *stream
 		return nil
 	}
 	msgs := new(streams)
-	for item := range rtmpStream.GetStreams().IterBuffered() {
-		if s, ok := item.Val.(*rtmp.Stream); ok {
+
+	rtmpStream.GetStreams().Range(func(key, val interface{}) bool {
+		if s, ok := val.(*rtmp.Stream); ok {
 			if s.GetReader() != nil {
-				msg := stream{item.Key, s.GetReader().Info().UID}
+				msg := stream{key.(string), s.GetReader().Info().UID}
 				msgs.Publishers = append(msgs.Publishers, msg)
 			}
 		}
-	}
+		return true
+	})
 
-	for item := range rtmpStream.GetStreams().IterBuffered() {
-		ws := item.Val.(*rtmp.Stream).GetWs()
-		for s := range ws.IterBuffered() {
-			if pw, ok := s.Val.(*rtmp.PackWriterCloser); ok {
+	rtmpStream.GetStreams().Range(func(key, val interface{}) bool {
+		ws := val.(*rtmp.Stream).GetWs()
+
+		ws.Range(func(k, v interface{}) bool {
+			if pw, ok := v.(*rtmp.PackWriterCloser); ok {
 				if pw.GetWriter() != nil {
-					msg := stream{item.Key, pw.GetWriter().Info().UID}
+					msg := stream{key.(string), pw.GetWriter().Info().UID}
 					msgs.Players = append(msgs.Players, msg)
 				}
 			}
-		}
-	}
+			return true
+		})
+		return true
+	})
 
 	return msgs
 }

--- a/protocol/rtmp/rtmp.go
+++ b/protocol/rtmp/rtmp.go
@@ -124,7 +124,7 @@ func (s *Server) handleConn(conn *core.Conn) error {
 	if connServer.IsPublisher() {
 		channel, err := configure.RoomKeys.GetChannel(name)
 		if err != nil {
-			err := fmt.Errorf("invalid key")
+			err := fmt.Errorf("invalid key err=%s", err.Error())
 			conn.Close()
 			log.Error("CheckKey err: ", err)
 			return err

--- a/protocol/rtmp/rtmp.go
+++ b/protocol/rtmp/rtmp.go
@@ -143,6 +143,7 @@ func (s *Server) handleConn(conn *core.Conn) error {
 			writer := s.getter.GetWriter(reader.Info())
 			s.handler.HandleWriter(writer)
 		}
+		//FIXME: should flv should be configurable, not always on -gs
 		flvWriter := new(flv.FlvDvr)
 		s.handler.HandleWriter(flvWriter.GetWriter(reader.Info()))
 	} else {

--- a/protocol/rtmp/rtmprelay/staticrelay.go
+++ b/protocol/rtmp/rtmprelay/staticrelay.go
@@ -21,19 +21,28 @@ type StaticPush struct {
 
 var G_StaticPushMap = make(map[string](*StaticPush))
 var g_MapLock = new(sync.RWMutex)
+var G_PushUrlList []string = nil
 
 var (
 	STATIC_RELAY_STOP_CTRL = "STATIC_RTMPRELAY_STOP"
 )
 
 func GetStaticPushList(appname string) ([]string, error) {
-	pushurlList, ok := configure.GetStaticPushUrlList(appname)
+	if G_PushUrlList == nil {
+		// Do not unmarshel the config every time, lots of reflect works -gs
+		pushurlList, ok := configure.GetStaticPushUrlList(appname)
+		if !ok {
+			G_PushUrlList = []string{}
+		} else {
+			G_PushUrlList = pushurlList
+		}
+	}
 
-	if !ok {
+	if len(G_PushUrlList) == 0 {
 		return nil, fmt.Errorf("no static push url")
 	}
 
-	return pushurlList, nil
+	return G_PushUrlList, nil
 }
 
 func GetAndCreateStaticPushObject(rtmpurl string) *StaticPush {


### PR DESCRIPTION
It almost increase 100%, and it's very close to nginx-rtmp-module. using srs-benchmark 1.2Mx1000 push streams, consuming about 1 cpu core when disable flv and hls(but currently the flv is always on, to be fixed),  beside, there are still lots of performance improvement work could be done, will do that when I'm free!