### PR TITLE
Disable hls setting ignored, allow keyless rtmp, cleaner logs.

### DIFF
--- a/configure/liveconfig.go
+++ b/configure/liveconfig.go
@@ -28,6 +28,8 @@ type Application struct {
 	Appname    string   `mapstructure:"appname"`
 	Live       bool     `mapstructure:"live"`
 	Hls        bool     `mapstructure:"hls"`
+	Flv        bool     `mapstructure:"flv"`
+	Api        bool     `mapstructure:"api"`
 	StaticPush []string `mapstructure:"static_push"`
 }
 
@@ -40,7 +42,9 @@ type JWT struct {
 type ServerCfg struct {
 	Level           string       `mapstructure:"level"`
 	ConfigFile      string       `mapstructure:"config_file"`
+	FLVArchive      bool         `mapstructure:"flv_archive"`
 	FLVDir          string       `mapstructure:"flv_dir"`
+	RTMPNoAuth      bool         `mapstructure:"rtmp_noauth"`
 	RTMPAddr        string       `mapstructure:"rtmp_addr"`
 	HTTPFLVAddr     string       `mapstructure:"httpflv_addr"`
 	HLSAddr         string       `mapstructure:"hls_addr"`
@@ -58,6 +62,8 @@ type ServerCfg struct {
 // default config
 var defaultConf = ServerCfg{
 	ConfigFile:      "livego.yaml",
+	FLVArchive:	false,
+	RTMPNoAuth:	false,
 	RTMPAddr:        ":1935",
 	HTTPFLVAddr:     ":7001",
 	HLSAddr:         ":7002",
@@ -70,6 +76,8 @@ var defaultConf = ServerCfg{
 		Appname:    "live",
 		Live:       true,
 		Hls:        true,
+		Flv:        true,
+		Api:        true,
 		StaticPush: nil,
 	}},
 }

--- a/livego.yaml
+++ b/livego.yaml
@@ -2,6 +2,7 @@
 # level: info
 
 # # FLV Options
+# flv_archive: false
 # flv_dir: "./tmp"
 # httpflv_addr: ":7001"
 
@@ -20,3 +21,5 @@ server:
 - appname: live
   live: true
   hls: true
+  api: true
+  flv: true

--- a/livego.yaml
+++ b/livego.yaml
@@ -6,6 +6,7 @@
 # httpflv_addr: ":7001"
 
 # # RTMP Options
+# rtmp_noauth: false
 # rtmp_addr: ":1935"
 # read_timeout: 10
 # write_timeout: 10

--- a/main.go
+++ b/main.go
@@ -134,13 +134,21 @@ func main() {
         version: %s
 	`, VERSION)
 
-	stream := rtmp.NewRtmpStream()
-	var hlsServer *hls.Server
-	if configure.Config.GetBool("hls") {
-		hlsServer = startHls()
-	}
-	startHTTPFlv(stream)
-	startAPI(stream)
+	apps := configure.Applications{}
+	configure.Config.UnmarshalKey("server", &apps)
+	for _, app := range apps {
+		stream := rtmp.NewRtmpStream()
+		var hlsServer *hls.Server
+		if app.Hls {
+			hlsServer = startHls()
+		}
+		if app.Flv {
+			startHTTPFlv(stream)
+		}
+		if app.Api {
+			startAPI(stream)
+		}
 
-	startRtmp(stream, hlsServer)
+		startRtmp(stream, hlsServer)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -135,7 +135,10 @@ func main() {
 	`, VERSION)
 
 	stream := rtmp.NewRtmpStream()
-	hlsServer := startHls()
+	var hlsServer *hls.Server
+	if configure.Config.GetBool("hls") {
+		hlsServer := startHls()
+	}
 	startHTTPFlv(stream)
 	startAPI(stream)
 

--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ func main() {
 	stream := rtmp.NewRtmpStream()
 	var hlsServer *hls.Server
 	if configure.Config.GetBool("hls") {
-		hlsServer := startHls()
+		hlsServer = startHls()
 	}
 	startHTTPFlv(stream)
 	startAPI(stream)

--- a/protocol/hls/source.go
+++ b/protocol/hls/source.go
@@ -58,7 +58,7 @@ func NewSource(info av.Info) *Source {
 	go func() {
 		err := s.SendPacket()
 		if err != nil {
-			log.Warning("send packet error: ", err)
+			log.Debug("send packet error: ", err)
 			s.closed = true
 		}
 	}()

--- a/protocol/httpflv/writer.go
+++ b/protocol/httpflv/writer.go
@@ -54,7 +54,7 @@ func NewFLVWriter(app, title, url string, ctx http.ResponseWriter) *FLVWriter {
 	go func() {
 		err := ret.SendPacket()
 		if err != nil {
-			log.Error("SendPacket error: ", err)
+			log.Debug("SendPacket error: ", err)
 			ret.closed = true
 		}
 

--- a/protocol/rtmp/rtmp.go
+++ b/protocol/rtmp/rtmp.go
@@ -153,9 +153,10 @@ func (s *Server) handleConn(conn *core.Conn) error {
 			writer := s.getter.GetWriter(reader.Info())
 			s.handler.HandleWriter(writer)
 		}
-		//FIXME: should flv should be configurable, not always on -gs
-		flvWriter := new(flv.FlvDvr)
-		s.handler.HandleWriter(flvWriter.GetWriter(reader.Info()))
+		if configure.Config.GetBool("flv_archive") {
+			flvWriter := new(flv.FlvDvr)
+			s.handler.HandleWriter(flvWriter.GetWriter(reader.Info()))
+		}
 	} else {
 		writer := NewVirWriter(connServer)
 		log.Debugf("new player: %+v", writer.Info())

--- a/protocol/rtmp/rtmp.go
+++ b/protocol/rtmp/rtmp.go
@@ -122,6 +122,16 @@ func (s *Server) handleConn(conn *core.Conn) error {
 
 	log.Debugf("handleConn: IsPublisher=%v", connServer.IsPublisher())
 	if connServer.IsPublisher() {
+		if configure.Config.GetBool("rtmp_noauth") {
+			key, err := configure.RoomKeys.GetKey(name)
+			if err != nil {
+				err := fmt.Errorf("Cannot create key err=%s", err.Error())
+				conn.Close()
+				log.Error("GetKey err: ", err)
+				return err
+			}
+			name = key
+		}
 		channel, err := configure.RoomKeys.GetChannel(name)
 		if err != nil {
 			err := fmt.Errorf("invalid key err=%s", err.Error())

--- a/protocol/webrtc/webrtc.go
+++ b/protocol/webrtc/webrtc.go
@@ -1,4 +1,0 @@
-package webrtc
-
-func startWebRTC() {
-}

--- a/protocol/webrtc/webrtc.go
+++ b/protocol/webrtc/webrtc.go
@@ -1,0 +1,4 @@
+package webrtc
+
+func startWebRTC() {
+}


### PR DESCRIPTION
The "hls" setting is present in the yaml configuration file was ignored.
This pull request fixes that.

This pull request also lets users disable the external authentication steps, useful for reverse-proxied configurations that manage authentication differently (see nginx-rtmp-module).

Send packet errors have been demoted to Debug since they're mostly users closing connections.