### PR TITLE
Fix Memory leak

### DIFF
--- a/container/flv/muxer.go
+++ b/container/flv/muxer.go
@@ -56,6 +56,7 @@ type FLVWriter struct {
 	buf             []byte
 	closed          chan struct{}
 	ctx             *os.File
+	closedWriter    bool
 }
 
 func NewFLVWriter(app, title, url string, ctx *os.File) *FLVWriter {
@@ -131,6 +132,10 @@ func (writer *FLVWriter) Wait() {
 }
 
 func (writer *FLVWriter) Close(error) {
+	if writer.closedWriter {
+		return
+	}
+	writer.closedWriter = true
 	writer.ctx.Close()
 	close(writer.closed)
 }

--- a/protocol/rtmp/stream.go
+++ b/protocol/rtmp/stream.go
@@ -379,7 +379,7 @@ func (s *Stream) CheckAlive() (n int) {
 		v := val.(*PackWriterCloser)
 		if v.w != nil {
 			//Alive from RWBaser, check last frame now - timestamp, if > timeout then Remove it
-			if !v.w.Alive() && s.isStart {
+			if !v.w.Alive() {
 				log.Infof("write timeout remove")
 				s.ws.Delete(key)
 				v.w.Close(fmt.Errorf("write timeout"))


### PR DESCRIPTION
I tested livego continuously and the memory kept increasing, suggesting there was memory leak somewhere. The culprit was the stream not being deleted.

When the pushing ends s.isStart is set to false, which  prevents the stream from being deleted, when CheckAlive() 
https://github.com/gwuhaolin/livego/blob/12948dfb67828b6569ab99eb43bd2298fd7622e6/protocol/rtmp/stream.go#L369

is called. Specifically:
https://github.com/gwuhaolin/livego/blob/12948dfb67828b6569ab99eb43bd2298fd7622e6/protocol/rtmp/stream.go#L382

I also added writerClosed to flvWriter to prevent closing it twice.