### PR TITLE
Update ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 tmp
 vendor
 livego
+livego.exe


### PR DESCRIPTION
Binary file `livego.exe` will be generated on windows platform, need to add `livego.exe` into ignore rules.