### PR TITLE
Correct initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,10 +37,8 @@ func startHls() *hls.Server {
 	return hlsServer
 }
 
-var rtmpAddr string
-
 func startRtmp(stream *rtmp.RtmpStream, hlsServer *hls.Server) {
-	rtmpAddr = configure.Config.GetString("rtmp_addr")
+	rtmpAddr := configure.Config.GetString("rtmp_addr")
 
 	rtmpListen, err := net.Listen("tcp", rtmpAddr)
 	if err != nil {
@@ -88,6 +86,7 @@ func startHTTPFlv(stream *rtmp.RtmpStream) {
 
 func startAPI(stream *rtmp.RtmpStream) {
 	apiAddr := configure.Config.GetString("api_addr")
+	rtmpAddr := configure.Config.GetString("rtmp_addr")
 
 	if apiAddr != "" {
 		opListen, err := net.Listen("tcp", apiAddr)


### PR DESCRIPTION
`rtmpAddr` is not initialized properly.

Take a look at initialization in `main.go`

```go
if app.Api {
    startAPI(stream)
}

startRtmp(stream, hlsServer)
```

When `startAPI` is called, `rtmpAddr` is not initialized. In fact, `rtmpAddr` is initialized after `startRtmp` is called.
