### PR TITLE
API: Let users get statistics for a single room

### DIFF
--- a/protocol/api/api.go
+++ b/protocol/api/api.go
@@ -152,6 +152,12 @@ func (server *Server) GetLiveStatics(w http.ResponseWriter, req *http.Request) {
 
 	defer res.SendJson()
 
+	room := ""
+
+	if err := req.ParseForm(); err == nil {
+		room = req.Form.Get("room")
+	}
+
 	rtmpStream := server.handler.(*rtmp.RtmpStream)
 	if rtmpStream == nil {
 		res.Status = 500
@@ -161,39 +167,76 @@ func (server *Server) GetLiveStatics(w http.ResponseWriter, req *http.Request) {
 
 	msgs := new(streams)
 
-	rtmpStream.GetStreams().Range(func(key, val interface{}) bool {
-		if s, ok := val.(*rtmp.Stream); ok {
-			if s.GetReader() != nil {
-				switch s.GetReader().(type) {
-				case *rtmp.VirReader:
-					v := s.GetReader().(*rtmp.VirReader)
-					msg := stream{key.(string), v.Info().URL, v.ReadBWInfo.StreamId, v.ReadBWInfo.VideoDatainBytes, v.ReadBWInfo.VideoSpeedInBytesperMS,
-						v.ReadBWInfo.AudioDatainBytes, v.ReadBWInfo.AudioSpeedInBytesperMS}
-					msgs.Publishers = append(msgs.Publishers, msg)
-				}
-			}
-		}
-		return true
-	})
-
-	rtmpStream.GetStreams().Range(func(key, val interface{}) bool {
-		ws := val.(*rtmp.Stream).GetWs()
-		ws.Range(func(k, v interface{}) bool {
-			if pw, ok := v.(*rtmp.PackWriterCloser); ok {
-				if pw.GetWriter() != nil {
-					switch pw.GetWriter().(type) {
-					case *rtmp.VirWriter:
-						v := pw.GetWriter().(*rtmp.VirWriter)
-						msg := stream{key.(string), v.Info().URL, v.WriteBWInfo.StreamId, v.WriteBWInfo.VideoDatainBytes, v.WriteBWInfo.VideoSpeedInBytesperMS,
-							v.WriteBWInfo.AudioDatainBytes, v.WriteBWInfo.AudioSpeedInBytesperMS}
-						msgs.Players = append(msgs.Players, msg)
+	if room == "" {
+		rtmpStream.GetStreams().Range(func(key, val interface{}) bool {
+			if s, ok := val.(*rtmp.Stream); ok {
+				if s.GetReader() != nil {
+					switch s.GetReader().(type) {
+					case *rtmp.VirReader:
+						v := s.GetReader().(*rtmp.VirReader)
+						msg := stream{key.(string), v.Info().URL, v.ReadBWInfo.StreamId, v.ReadBWInfo.VideoDatainBytes, v.ReadBWInfo.VideoSpeedInBytesperMS,
+							v.ReadBWInfo.AudioDatainBytes, v.ReadBWInfo.AudioSpeedInBytesperMS}
+						msgs.Publishers = append(msgs.Publishers, msg)
 					}
 				}
 			}
 			return true
 		})
-		return true
-	})
+
+		rtmpStream.GetStreams().Range(func(key, val interface{}) bool {
+			ws := val.(*rtmp.Stream).GetWs()
+			ws.Range(func(k, v interface{}) bool {
+				if pw, ok := v.(*rtmp.PackWriterCloser); ok {
+					if pw.GetWriter() != nil {
+						switch pw.GetWriter().(type) {
+						case *rtmp.VirWriter:
+							v := pw.GetWriter().(*rtmp.VirWriter)
+							msg := stream{key.(string), v.Info().URL, v.WriteBWInfo.StreamId, v.WriteBWInfo.VideoDatainBytes, v.WriteBWInfo.VideoSpeedInBytesperMS,
+								v.WriteBWInfo.AudioDatainBytes, v.WriteBWInfo.AudioSpeedInBytesperMS}
+							msgs.Players = append(msgs.Players, msg)
+						}
+					}
+				}
+				return true
+			})
+			return true
+		})
+	} else {
+        // Warning: The room should be in the "live/stream" format!
+		roomInfo, exists := (rtmpStream.GetStreams()).Load(room)
+		if exists == false {
+			res.Status = 404
+			res.Data = "room not found or inactive"
+			return
+		}
+
+		if s, ok := roomInfo.(*rtmp.Stream); ok {
+			if s.GetReader() != nil {
+				switch s.GetReader().(type) {
+				case *rtmp.VirReader:
+					v := s.GetReader().(*rtmp.VirReader)
+					msg := stream{room, v.Info().URL, v.ReadBWInfo.StreamId, v.ReadBWInfo.VideoDatainBytes, v.ReadBWInfo.VideoSpeedInBytesperMS,
+						v.ReadBWInfo.AudioDatainBytes, v.ReadBWInfo.AudioSpeedInBytesperMS}
+					msgs.Publishers = append(msgs.Publishers, msg)
+				}
+			}
+
+			s.GetWs().Range(func(k, v interface{}) bool {
+				if pw, ok := v.(*rtmp.PackWriterCloser); ok {
+					if pw.GetWriter() != nil {
+						switch pw.GetWriter().(type) {
+						case *rtmp.VirWriter:
+							v := pw.GetWriter().(*rtmp.VirWriter)
+							msg := stream{room, v.Info().URL, v.WriteBWInfo.StreamId, v.WriteBWInfo.VideoDatainBytes, v.WriteBWInfo.VideoSpeedInBytesperMS,
+								v.WriteBWInfo.AudioDatainBytes, v.WriteBWInfo.AudioSpeedInBytesperMS}
+							msgs.Players = append(msgs.Players, msg)
+						}
+					}
+				}
+				return true
+			})
+		}
+	}
 
 	//resp, _ := json.Marshal(msgs)
 	res.Data = msgs


### PR DESCRIPTION
Requires URLs in the `/stat/livestat?room=live/room` format.
Previous behavior is available if you don't specify the `room` parameter.