### PR TITLE
fix: allow slash character into appname

### DIFF
--- a/container/flv/muxer.go
+++ b/container/flv/muxer.go
@@ -150,15 +150,11 @@ func (writer *FLVWriter) Info() (ret av.Info) {
 type FlvDvr struct{}
 
 func (f *FlvDvr) GetWriter(info av.Info) av.WriteCloser {
-	paths := strings.SplitN(info.Key, "/", 2)
-	if len(paths) != 2 {
-		log.Warning("invalid info")
-		return nil
-	}
+	paths := strings.Split(info.Key, "/")
 
 	flvDir := configure.Config.GetString("flv_dir")
 
-	err := os.MkdirAll(path.Join(flvDir, paths[0]), 0755)
+	err := os.MkdirAll(path.Join(append([]string{flvDir}, paths[:len(paths)-1]...)...), 0755)
 	if err != nil {
 		log.Error("mkdir error: ", err)
 		return nil
@@ -172,7 +168,7 @@ func (f *FlvDvr) GetWriter(info av.Info) av.WriteCloser {
 		return nil
 	}
 
-	writer := NewFLVWriter(paths[0], paths[1], info.URL, w)
+	writer := NewFLVWriter(strings.Join(paths[:len(paths)-1], "/"), paths[len(paths)-1], info.URL, w)
 	log.Debug("new flv dvr: ", writer.Info())
 	return writer
 }

--- a/protocol/hls/hls.go
+++ b/protocol/hls/hls.go
@@ -159,12 +159,8 @@ func (server *Server) parseM3u8(pathstr string) (key string, err error) {
 
 func (server *Server) parseTs(pathstr string) (key string, err error) {
 	pathstr = strings.TrimLeft(pathstr, "/")
-	paths := strings.SplitN(pathstr, "/", 3)
-	if len(paths) != 3 {
-		err = fmt.Errorf("invalid path=%s", pathstr)
-		return
-	}
-	key = paths[0] + "/" + paths[1]
+	paths := strings.Split(pathstr, "/")	
+	key = strings.Join(paths[:len(paths)-1], "/")
 
 	return
 }

--- a/protocol/rtmp/rtmp.go
+++ b/protocol/rtmp/rtmp.go
@@ -134,7 +134,7 @@ func (s *Server) handleConn(conn *core.Conn) error {
 		}
 		channel, err := configure.RoomKeys.GetChannel(name)
 		if err != nil {
-			err := fmt.Errorf("invalid key err=%s", err.Error())
+			err := fmt.Errorf("invalid key err=%s, name=%s", err.Error(), name)
 			conn.Close()
 			log.Error("CheckKey err: ", err)
 			return err


### PR DESCRIPTION
## Problem
When trying to add an appname with a slash like 'live/0' the `parseTs` function was returning an invalid key.

## Solution
After searching I saw that the function was considered to have always a slice of 3 positions and ignored the last one.
So, I changed the function to receive all but the last element, without considering the slice size.