### PR TITLE
feat: Add FLV recording configuration option

### DIFF
--- a/configure/liveconfig.go
+++ b/configure/liveconfig.go
@@ -128,6 +128,7 @@ func initDefault() {
 	pflag.String("config_file", "livego.yaml", "configure filename")
 	pflag.String("level", "info", "Log level")
 	pflag.Bool("hls_keep_after_end", false, "Maintains the HLS after the stream ends")
+	pflag.Bool("flv_archive", false, "Enable or disable FLV recording. If set to true, the server will record the live stream as FLV files.")
 	pflag.String("flv_dir", "tmp", "output flv file at flvDir/APP/KEY_TIME.flv")
 	pflag.Int("read_timeout", 10, "read time out")
 	pflag.Int("write_timeout", 10, "write time out")


### PR DESCRIPTION
### Description  

This pull request adds a configuration option for FLV recording, addressing the storage path issue discussed in [[#233](https://github.com/gwuhaolin/livego/issues/233)](https://github.com/gwuhaolin/livego/issues/233).  

Key changes include:  
- Added a new configuration option `flv_archive` to enable or disable FLV recording.  
- Ensured compatibility with existing functionality.  

### Motivation  

This PR resolves the issue [#233](https://github.com/gwuhaolin/livego/issues/233) by introducing a flexible and user-configurable option for managing FLV recordings. Users can now control whether to enable FLV recording and specify storage paths, improving usability and configurability.  

### Related Issues  

- [FLV storage path #233](https://github.com/gwuhaolin/livego/issues/233)

### Screenshots 
#### before modification

![image](https://github.com/user-attachments/assets/f2be4a08-44e8-47d6-a5f1-6d84f205c5a9)


#### after 
![image](https://github.com/user-attachments/assets/80b3149c-aae3-4315-a895-ed09eeb0b6e9)

---  

